### PR TITLE
SignColumn can be NONE for transparent

### DIFF
--- a/colors/deus.vim
+++ b/colors/deus.vim
@@ -81,6 +81,7 @@ let s:is_dark=(&background == 'dark')
 " setup palette dictionary
 let s:ds = {}
 
+let s:ds.none = ['NONE', 'NONE']
 
 " fill it with absolute colors
 let s:ds.dark0       = ['#2C323B', 235]     " 40-40-40 Background


### PR DESCRIPTION
I am configuring my neovim to be transparent, however SignColumn isn't transparent when i use vim-dues. So I do this.

```vim
" make SignColumn transparent
let g:deus_sign_column = 'none'
```